### PR TITLE
Update Clockwork Crate and READMEs

### DIFF
--- a/distributor/Cargo.lock
+++ b/distributor/Cargo.lock
@@ -802,8 +802,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-crank"
-version = "1.0.4"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#9f8ac8a9a1a23aba0645d3aec7a111e98c52cb62"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ecc6c9ab16584d4f4d743d9004f484357b1598529e10e9d74c0dff9333588a"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -813,8 +814,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-cron"
-version = "1.0.4"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#9f8ac8a9a1a23aba0645d3aec7a111e98c52cb62"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467d8a0ecb366844ab2df41dfa27e08eeed308687ab93f248ef0bb86bf35eb"
 dependencies = [
  "chrono",
  "nom",
@@ -823,8 +825,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-pool"
-version = "1.0.4"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#9f8ac8a9a1a23aba0645d3aec7a111e98c52cb62"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cb11279caded9dab3779ed52c82545b4d7328aa11aee18eb540e14a86a7b5b"
 dependencies = [
  "anchor-lang",
 ]

--- a/distributor/README.md
+++ b/distributor/README.md
@@ -4,17 +4,28 @@
 - Make sure you have both the [solana cli](https://docs.solana.com/cli/install-solana-cli-tools) and [anchor cli](https://project-serum.github.io/anchor/getting-started/installation.html#build-from-source-for-other-operating-systems) installed on your computer.
 - clone the [clockwork repo](https://github.com/clockwork-xyz/clockwork/) locally to your machine 
 
-## Deploying Distributor Program
+## Localnet
 - run `anchor build` in the root directory of `distributor`
 - run `solana address -k target/deploy/distributor-keypair.json` to get your program's ID
 - copy that ID and replace it with the Program ID in `id.rs` and the `Anchor.toml` files
 - run `anchor build` again
 - be sure to set your solana config to devnet with `solana config set --url http://localhost:8899`
+- make sure in your `Anchor.toml` file that your cluster is set to `localnet`
 - if you have the [clockwork repo](https://github.com/clockwork-xyz/clockwork/#getting-started) and you've followed the [getting started](https://github.com/clockwork-xyz/clockwork/#getting-started) guide on how to build from source you can run the following command
   ```bash
   clockwork localnet --bpf-program <PATH TO THIS FILE>/clockwork-xyz/examples/distributor/target/deploy/distributor-keypair.json <PATH TO THIS FILE>/clockwork-xyz/examples/distributor/target/deploy/distributor.so
   ```
-
-## Invoking Distributor Program
 - navigate to the `client` directory
 - run `cargo run` 
+
+## Devnet
+- run `anchor build` in the root directory of `distributor`
+- run `solana address -k target/deploy/distributor-keypair.json` to get your program's ID
+- copy that ID and replace it with the Program ID in `id.rs` and `Anchor.toml`
+- run `anchor build` again
+- be sure to set your solana config to devnet with `solana config set --url https://api.devnet.solana.com`
+- make sure in your `Anchor.toml` file that your cluster is set to `devnet`
+- airdrop yourself a few times with `solana airdrop 2`
+- run `anchor deploy`
+- navigate to the `client` directory
+- run `cargo run --features devnet` 

--- a/distributor/client/Cargo.toml
+++ b/distributor/client/Cargo.toml
@@ -3,12 +3,13 @@ name = "client"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anchor-lang = "0.25.0"
 anchor-spl = { version = "0.25.0", features = ["dex"] }
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main" }
+clockwork-crank = "1.0.5"
 distributor = { path = "../programs/distributor", features = ["no-entrypoint"], version = "0.1.0" }
 solana-client-helpers = "1.1.0"
 solana-sdk = "1.10.29"
+
+[features]
+devnet = []

--- a/distributor/client/src/main.rs
+++ b/distributor/client/src/main.rs
@@ -14,7 +14,10 @@ use {
 
 fn main() -> ClientResult<()> {
     // Create Client
-    let client = RpcClient::new("http://localhost:8899");
+    #[cfg(feature = "devnet")]
+    let client = RpcClient::new("https://api.devnet.solana.com");
+    #[cfg(not(feature = "devnet"))]
+    let client = RpcClient::new("http://localhost:8899");    
     let payer = Keypair::new();
     let client = Client { client, payer };
 

--- a/distributor/programs/distributor/Cargo.toml
+++ b/distributor/programs/distributor/Cargo.toml
@@ -21,4 +21,4 @@ overflow-checks = true
 [dependencies]
 anchor-lang = "0.25.0" 
 anchor-spl = { version = "0.25.0", features = ["token"] }
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main", features = ["cpi"] }
+clockwork-crank = { version = "1.0.5", features = ["cpi"] }

--- a/hello_clockwork/Anchor.toml
+++ b/hello_clockwork/Anchor.toml
@@ -2,10 +2,10 @@
 seeds = false
 
 [programs.devnet]
-hello_clockwork = "44KismN5u53sKPtbFSWhVFtt8kBQH74EvAKHbdSd9tZz"
+hello_clockwork = "EGdyrcP3mm4u2M7c2igJaj82qYbKFXkJ69uQ6M8yjJT2"
 
 [programs.localnet]
-hello_clockwork = "44KismN5u53sKPtbFSWhVFtt8kBQH74EvAKHbdSd9tZz"
+hello_clockwork = "EGdyrcP3mm4u2M7c2igJaj82qYbKFXkJ69uQ6M8yjJT2"
 
 [registry]
 url = "https://anchor.projectserum.com"

--- a/hello_clockwork/Cargo.lock
+++ b/hello_clockwork/Cargo.lock
@@ -755,8 +755,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-crank"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ecc6c9ab16584d4f4d743d9004f484357b1598529e10e9d74c0dff9333588a"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -766,8 +767,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-cron"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467d8a0ecb366844ab2df41dfa27e08eeed308687ab93f248ef0bb86bf35eb"
 dependencies = [
  "chrono",
  "nom",
@@ -776,8 +778,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-pool"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cb11279caded9dab3779ed52c82545b4d7328aa11aee18eb540e14a86a7b5b"
 dependencies = [
  "anchor-lang",
 ]

--- a/hello_clockwork/Cargo.toml
+++ b/hello_clockwork/Cargo.toml
@@ -3,6 +3,3 @@ members = [
     "client",
     "programs/*"
 ]
-
-[patch.crates-io]
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main" }

--- a/hello_clockwork/README.md
+++ b/hello_clockwork/README.md
@@ -4,16 +4,28 @@
 - Make sure you have both the [solana cli](https://docs.solana.com/cli/install-solana-cli-tools) and [anchor cli](https://project-serum.github.io/anchor/getting-started/installation.html#build-from-source-for-other-operating-systems) installed on your computer.
 - clone the [clockwork repo](https://github.com/clockwork-xyz/clockwork/) locally to your machine 
 
-## Deploying Hello Clockwork
+## Localnet
 - run `anchor build` in the root directory of `hello_clockwork`
 - run `solana address -k target/deploy/hello_clockwork-keypair.json` to get your program's ID
 - copy that ID and replace it with the Program ID in `id.rs` and `Anchor.toml`
 - run `anchor build` again
 - be sure to set your solana config to devnet with `solana config set --url http://localhost:8899`
+- make sure in your `Anchor.toml` file that your cluster is set to `localnet`
 - if you have the [clockwork repo](https://github.com/clockwork-xyz/clockwork/#getting-started) and you've followed the [getting started](https://github.com/clockwork-xyz/clockwork/#getting-started) guide on how to build from source you can run the following command
   ```bash
   clockwork localnet --bpf-program <PATH TO THIS FILE>/clockwork-xyz/examples/hello_clockwork/target/deploy/hello_clockwork-keypair.json <PATH TO THIS FILE>/clockwork-xyz/examples/hello_clockwork/target/deploy/hello_clockwork.so
   ```
-## Invoking Hello Clockwork Program
-- navigate to the `client` directory
+- In a new terminal navigate to the `client` directory
 - run `cargo run` 
+
+## Devnet
+- run `anchor build` in the root directory of `hello_clockwork`
+- run `solana address -k target/deploy/hello_clockwork-keypair.json` to get your program's ID
+- copy that ID and replace it with the Program ID in `id.rs` and `Anchor.toml`
+- run `anchor build` again
+- be sure to set your solana config to devnet with `solana config set --url https://api.devnet.solana.com`
+- make sure in your `Anchor.toml` file that your cluster is set to `devnet`
+- airdrop yourself a few times with `solana airdrop 2`
+- run `anchor deploy`
+- navigate to the `client` directory
+- run `cargo run --features devnet` 

--- a/hello_clockwork/client/Cargo.toml
+++ b/hello_clockwork/client/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2021"
 
 [dependencies]
 hello-clockwork = { path = "../programs/hello_clockwork", features = ["no-entrypoint"], version = "0.1.0" }
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main"}
+clockwork-crank = "1.0.5"
 anchor-lang = "0.25.0"
 solana-client-helpers = "1.1.0"
 solana-sdk = "1.10.29"
+
+[features]
+devnet = []

--- a/hello_clockwork/client/src/main.rs
+++ b/hello_clockwork/client/src/main.rs
@@ -13,7 +13,11 @@ use {
 
 fn main() -> ClientResult<()> {
     // Create Client
+    #[cfg(feature = "devnet")]
+    let client = RpcClient::new("https://api.devnet.solana.com");
+    #[cfg(not(feature = "devnet"))]
     let client = RpcClient::new("http://localhost:8899");
+
     let payer = Keypair::new();
     let client = Client { client, payer };
     client.airdrop(&client.payer_pubkey(), 2 * LAMPORTS_PER_SOL)?;

--- a/hello_clockwork/programs/hello_clockwork/Cargo.toml
+++ b/hello_clockwork/programs/hello_clockwork/Cargo.toml
@@ -20,4 +20,4 @@ overflow-checks = true
 
 [dependencies]
 anchor-lang = "0.25.0"
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main", features = ["cpi"] }
+clockwork-crank = { version = "1.0.5", features = ["cpi"] }

--- a/hello_clockwork/programs/hello_clockwork/src/id.rs
+++ b/hello_clockwork/programs/hello_clockwork/src/id.rs
@@ -1,3 +1,3 @@
 use anchor_lang::prelude::declare_id;
 
-declare_id!("44KismN5u53sKPtbFSWhVFtt8kBQH74EvAKHbdSd9tZz");
+declare_id!("EGdyrcP3mm4u2M7c2igJaj82qYbKFXkJ69uQ6M8yjJT2");

--- a/hello_clockwork/programs/hello_clockwork/src/instructions/initialize.rs
+++ b/hello_clockwork/programs/hello_clockwork/src/instructions/initialize.rs
@@ -52,7 +52,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Initialize<'info>>) -> Res
     let system_program = &ctx.accounts.system_program;
 
     // define ix
-    let hello_clowckwork_ix = Instruction {
+    let hello_clockwork_ix = Instruction {
         program_id: crate::ID,
         accounts: vec![ 
             AccountMeta::new_readonly(authority.key(), false),
@@ -74,7 +74,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Initialize<'info>>) -> Res
             },
             &[&[SEED_AUTHORITY, &[bump]]],
         ),
-        hello_clowckwork_ix.into(),
+        hello_clockwork_ix.into(),
         "hello".into(),
         Trigger::Cron {
             schedule: "*/15 * * * * * *".into(),

--- a/investments/Cargo.lock
+++ b/investments/Cargo.lock
@@ -796,8 +796,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-crank"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ecc6c9ab16584d4f4d743d9004f484357b1598529e10e9d74c0dff9333588a"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -807,8 +808,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-cron"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467d8a0ecb366844ab2df41dfa27e08eeed308687ab93f248ef0bb86bf35eb"
 dependencies = [
  "chrono",
  "nom",
@@ -817,8 +819,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-pool"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cb11279caded9dab3779ed52c82545b4d7328aa11aee18eb540e14a86a7b5b"
 dependencies = [
  "anchor-lang",
 ]

--- a/investments/README.md
+++ b/investments/README.md
@@ -4,6 +4,7 @@
 - Make sure you have both the [solana cli](https://docs.solana.com/cli/install-solana-cli-tools) and [anchor cli](https://project-serum.github.io/anchor/getting-started/installation.html#build-from-source-for-other-operating-systems) installed on your computer.
 - clone the [clockwork repo](https://github.com/clockwork-xyz/clockwork/) locally to your machine
 
+## Localnet
 ### Investments 
 - run `anchor build` in the root directory of `investments`
 - run `solana address -k target/deploy/investments-keypair.json` to get your program's ID
@@ -21,7 +22,6 @@
   ```bash
   clockwork localnet --bpf-program 9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin <PATH TO THIS FILE>/clockwork-xyz/examples/investments/dex/serum_dex.so --bpf-program <PATH TO THIS FILE>/clockwork-xyz/examples/investments/target/deploy/serum_crank-keypair.json <PATH TO THIS FILE>/clockwork-xyz/examples/investments/target/deploy/serum_crank.so --bpf-program <PATH TO THIS FILE>/clockwork-xyz/examples/investments/target/deploy/investments_program-keypair.json <PATH TO THIS FILE>/clockwork-xyz/examples/investments/target/deploy/investments_program.so
   ```
-
-## Invoking Investments Program
+### Client
 - navigate to the `client` directory
 - run `cargo run` 

--- a/investments/client/Cargo.toml
+++ b/investments/client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 investments-program = { path = "../programs/investments", features = ["no-entrypoint"], version = "0.1.0" }
 serum-crank = { path = "../../serum_crank/programs/serum_crank", features = ["no-entrypoint"], version = "0.1.0" }
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main"}
+clockwork-crank = "1.0.5"
 anchor-spl = { version = "0.25.0", features = ["dex"] }
 anchor-lang = "0.25.0"
 solana-sdk = "1.10.29"

--- a/investments/client/src/main.rs
+++ b/investments/client/src/main.rs
@@ -1,19 +1,14 @@
-use std::num::NonZeroU64;
-
-use anchor_spl::{
-    associated_token,
-    dex::serum_dex::{
-        instruction::{NewOrderInstructionV3, SelfTradeBehavior},
-        matching::{OrderType, Side},
-    },
-};
-
 mod utils;
 
 use {
     anchor_lang::{prelude::*, solana_program::sysvar, system_program, InstructionData},
     anchor_spl::{
-        dex::serum_dex::{instruction::initialize_market, state::OpenOrders},
+        associated_token,
+        dex::serum_dex::{
+            instruction::{initialize_market, NewOrderInstructionV3, SelfTradeBehavior},
+            matching::{OrderType, Side},
+            state::OpenOrders,
+        },
         token,
     },
     serum_common::client::rpc::mint_to_new_account,
@@ -22,7 +17,7 @@ use {
         instruction::Instruction, native_token::LAMPORTS_PER_SOL, signature::Keypair,
         signer::Signer,
     },
-    std::mem::size_of,
+    std::{mem::size_of, num::NonZeroU64},
     utils::*,
 };
 

--- a/investments/programs/investments/Cargo.toml
+++ b/investments/programs/investments/Cargo.toml
@@ -21,4 +21,4 @@ overflow-checks = true
 [dependencies]
 anchor-spl = { version = "0.25.0", features = ["dex"] }
 anchor-lang = "0.25.0"
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main", features = ["cpi"] }
+clockwork-crank = { version = "1.0.5", features = ["cpi"] }

--- a/payments/Cargo.lock
+++ b/payments/Cargo.lock
@@ -796,8 +796,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-crank"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ecc6c9ab16584d4f4d743d9004f484357b1598529e10e9d74c0dff9333588a"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -807,8 +808,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-cron"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467d8a0ecb366844ab2df41dfa27e08eeed308687ab93f248ef0bb86bf35eb"
 dependencies = [
  "chrono",
  "nom",
@@ -817,8 +819,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-pool"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cb11279caded9dab3779ed52c82545b4d7328aa11aee18eb540e14a86a7b5b"
 dependencies = [
  "anchor-lang",
 ]

--- a/payments/README.md
+++ b/payments/README.md
@@ -4,17 +4,28 @@
 - Make sure you have both the [solana cli](https://docs.solana.com/cli/install-solana-cli-tools) and [anchor cli](https://project-serum.github.io/anchor/getting-started/installation.html#build-from-source-for-other-operating-systems) installed on your computer.
 - clone the [clockwork repo](https://github.com/clockwork-xyz/clockwork/) locally to your machine 
 
-## Deploying Payments Program
-- run `anchor build` in the root directory of `payments_program`
+## Localnet
+- run `anchor build` in the root directory of `payments`
 - run `solana address -k target/deploy/payments_program-keypair.json` to get your program's ID
 - copy that ID and replace it with the Program ID in `id.rs` and the `Anchor.toml` files
 - run `anchor build` again
 - be sure to set your solana config to devnet with `solana config set --url http://localhost:8899`
+- make sure in your `Anchor.toml` file that your cluster is set to `localnet`
 - if you have the [clockwork repo](https://github.com/clockwork-xyz/clockwork/#getting-started) and you've followed the [getting started](https://github.com/clockwork-xyz/clockwork/#getting-started) guide on how to build from source you can run the following command
   ```bash
   clockwork localnet --bpf-program <PATH TO THIS FILE>/clockwork-xyz/examples/payments/target/deploy/payments_program-keypair.json <PATH TO THIS FILE>/clockwork-xyz/examples/payments/target/deploy/payments_program.so
   ```
-
-## Invoking Payments Program
-- navigate to the `client` directory
+- In a new terminal navigate to the `client` directory
 - run `cargo run` 
+
+## Devnet
+- run `anchor build` in the root directory of `payments`
+- run `solana address -k target/deploy/payment_program-keypair.json` to get your program's ID
+- copy that ID and replace it with the Program ID in `id.rs` and `Anchor.toml`
+- run `anchor build` again
+- be sure to set your solana config to devnet with `solana config set --url https://api.devnet.solana.com`
+- make sure in your `Anchor.toml` file that your cluster is set to `devnet`
+- airdrop yourself a few times with `solana airdrop 2`
+- run `anchor deploy`
+- navigate to the `client` directory
+- run `cargo run --features devnet` 

--- a/payments/client/Cargo.toml
+++ b/payments/client/Cargo.toml
@@ -5,9 +5,12 @@ edition = "2021"
 
 [dependencies]
 payments-program = { path = "../programs/payments", features = ["no-entrypoint"], version = "0.1.0" }
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main"}
+clockwork-crank = "1.0.5"
 anchor-spl = "0.25.0"
 anchor-lang = "0.25.0"
 solana-sdk = "1.10.29"
 solana-client = "1.10.29"
 solana-client-helpers = "1.1.0"
+
+[features]
+devnet = []

--- a/payments/client/src/main.rs
+++ b/payments/client/src/main.rs
@@ -14,8 +14,10 @@ use {
 
 fn main() -> ClientResult<()> {
     // Create Client
+    #[cfg(feature = "devnet")]
+    let client = RpcClient::new("https://api.devnet.solana.com");
+    #[cfg(not(feature = "devnet"))]
     let client = RpcClient::new("http://localhost:8899");
-    // let client = RpcClient::new("https://api.devnet.solana.com");
     let payer = Keypair::new();
     let client = Client { client, payer };
     client.airdrop(&client.payer_pubkey(), 2 * LAMPORTS_PER_SOL)?;

--- a/payments/programs/payments/Cargo.toml
+++ b/payments/programs/payments/Cargo.toml
@@ -21,4 +21,4 @@ overflow-checks = true
 [dependencies]
 anchor-spl = { version = "0.25.0", features = ["token"] }
 anchor-lang = "0.25.0" 
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main", features = ["cpi"]}
+clockwork-crank = { version = "1.0.5", features = ["cpi"] }

--- a/payments/programs/payments/src/lib.rs
+++ b/payments/programs/payments/src/lib.rs
@@ -12,6 +12,9 @@ use instructions::*;
 pub mod payments_program {
     use super::*;
 
+    /*
+     * initialize relevant accounts and clockwork queue for automated payment flow
+     */
     pub fn create_payment<'info>(
         ctx: Context<'_, '_, '_, 'info, CreatePayment<'info>>,
         disbursement_amount: u64,
@@ -20,6 +23,18 @@ pub mod payments_program {
         create_payment::handler(ctx, disbursement_amount, schedule)
     }
 
+    /*
+     * disburse payment from program authority's ATA to recipient's ATA
+     */
+    pub fn disburse_payment<'info>(
+        ctx: Context<'_, '_, '_, 'info, DisbursePayment<'info>>,
+    ) -> Result<clockwork_crank::state::CrankResponse> {
+        disburse_payment::handler(ctx)
+    }
+
+    /*
+     * deposit into program authority's ATA
+     */
     pub fn top_up_payment<'info>(
         ctx: Context<'_, '_, '_, 'info, TopUpPayment<'info>>,
         amount: u64,
@@ -27,18 +42,14 @@ pub mod payments_program {
         top_up_payment::handler(ctx, amount)
     }
 
-    // TODO: Queue update interface not ready yet
-    // pub fn update_payment<'info>(
-    //     ctx: Context<'_, '_, '_, 'info, UpdatePayment<'info>>,
-    //     disbursement_amount: Option<u64>,
-    //     schedule: Option<String>,
-    // ) -> Result<()> {
-    //     update_payment::handler(ctx, disbursement_amount, schedule)
-    // }
-
-    pub fn disburse_payment<'info>(
-        ctx: Context<'_, '_, '_, 'info, DisbursePayment<'info>>,
-    ) -> Result<clockwork_crank::state::CrankResponse> {
-        disburse_payment::handler(ctx)
+    /*
+     * update disbursement amount and/or schedule
+     */
+    pub fn update_payment<'info>(
+        ctx: Context<'_, '_, '_, 'info, UpdatePayment<'info>>,
+        disbursement_amount: Option<u64>,
+        schedule: Option<clockwork_crank::state::Trigger>,
+    ) -> Result<()> {
+        update_payment::handler(ctx, disbursement_amount, schedule)
     }
 }

--- a/serum_crank/Cargo.lock
+++ b/serum_crank/Cargo.lock
@@ -796,8 +796,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-crank"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ecc6c9ab16584d4f4d743d9004f484357b1598529e10e9d74c0dff9333588a"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -807,8 +808,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-cron"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467d8a0ecb366844ab2df41dfa27e08eeed308687ab93f248ef0bb86bf35eb"
 dependencies = [
  "chrono",
  "nom",
@@ -817,8 +819,9 @@ dependencies = [
 
 [[package]]
 name = "clockwork-pool"
-version = "1.0.3"
-source = "git+https://github.com/clockwork-xyz/clockwork?branch=main#7ce58af410e469823cd152ad6ce553d2ae0b9503"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cb11279caded9dab3779ed52c82545b4d7328aa11aee18eb540e14a86a7b5b"
 dependencies = [
  "anchor-lang",
 ]

--- a/serum_crank/README.md
+++ b/serum_crank/README.md
@@ -4,7 +4,7 @@
 - Make sure you have both the [solana cli](https://docs.solana.com/cli/install-solana-cli-tools) and [anchor cli](https://project-serum.github.io/anchor/getting-started/installation.html#build-from-source-for-other-operating-systems) installed on your computer.
 - clone the [clockwork repo](https://github.com/clockwork-xyz/clockwork/) locally to your machine 
 
-## Deploying Serum Crank
+## Localnet
 - run `anchor build` in the root directory of `serum_crank`
 - run `solana address -k target/deploy/serum_crank-keypair.json` to get your program's ID
 - copy that ID and replace it with the Program ID in `id.rs`
@@ -14,7 +14,17 @@
   ```bash
   clockwork localnet --bpf-program 9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin <PATH TO THIS FILE>/clockwork-xyz/examples/serum_crank/dex/serum_dex.so --bpf-program <PATH TO THIS FILE>/clockwork-xyz/examples/serum_crank/target/deploy/serum_crank-keypair.json <PATH TO THIS FILE>/clockwork-xyz/examples/serum_crank/target/deploy/serum_crank.so
   ```
-
-## Invoking Serum Crank Program
 - navigate to the `client` directory
 - run `cargo run` 
+
+## Devnet
+- run `anchor build` in the root directory of `serum_crank`
+- run `solana address -k target/deploy/serum_crank-keypair.json` to get your program's ID
+- copy that ID and replace it with the Program ID in `id.rs`
+- run `anchor build` again
+- be sure to set your solana config to devnet with `solana config set --url https://api.devnet.solana.com`
+- make sure in your `Anchor.toml` file that your cluster is set to `devnet`
+- airdrop yourself a few times with `solana airdrop 2`
+- run `anchor deploy`
+- navigate to the `client` directory
+- run `cargo run --features devnet` 

--- a/serum_crank/client/Cargo.toml
+++ b/serum_crank/client/Cargo.toml
@@ -5,10 +5,13 @@ edition = "2021"
 
 [dependencies]
 serum-crank = { path = "../programs/serum_crank", features = ["no-entrypoint"], version = "0.1.0" }
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main"}
+clockwork-crank = "1.0.5"
 anchor-spl = { version = "0.25.0", features = ["dex"] }
 anchor-lang = "0.25.0"
 solana-sdk = "1.10.29"
 solana-client = "1.10.29"
 solana-client-helpers = "1.1.0"
 serum-common = { version = "0.4.7", features = ["client"] }
+
+[features]
+devnet = []

--- a/serum_crank/client/src/main.rs
+++ b/serum_crank/client/src/main.rs
@@ -24,6 +24,9 @@ use {
 
 fn main() -> ClientResult<()> {
     // Create Client
+    #[cfg(feature = "devnet")]
+    let client = RpcClient::new("https://api.devnet.solana.com");
+    #[cfg(not(feature = "devnet"))]
     let client = RpcClient::new("http://localhost:8899");
     let payer = Keypair::new();
     let client = Client { client, payer };

--- a/serum_crank/programs/serum_crank/Cargo.toml
+++ b/serum_crank/programs/serum_crank/Cargo.toml
@@ -21,5 +21,5 @@ overflow-checks = true
 [dependencies]
 anchor-spl = { version = "0.25.0", features = ["dex"] }
 anchor-lang = "0.25.0"
-clockwork-crank = { git = "https://github.com/clockwork-xyz/clockwork", branch = "main", features = ["cpi"] }
+clockwork-crank = { version = "1.0.5", features = ["cpi"] }
 safe-transmute = "0.11.0"


### PR DESCRIPTION
- update READMEs with deployment instructions for both localnet and devnet
- add feature flag when invoking client depending on whether on localnet or devnet
- fix typo in the `initialize` ix for `hello_clockwork` example
- reintroduce `update_payment` ix in `payments` example now that the queue interface exists
- update all references to `clockwork_crank` to `v1.0.5`