### PR TITLE
Payments Example: Remove queue update from update payment ix

### DIFF
--- a/payments/client/src/main.rs
+++ b/payments/client/src/main.rs
@@ -3,7 +3,7 @@ use {
     anchor_spl::{associated_token, token},
     clockwork_sdk::{
         client::{
-            queue_program::{self, instruction::queue_create, objects::Trigger},
+            queue_program::{instruction::queue_create, objects::Trigger},
             Client, ClientResult, SplToken,
         },
         PAYER_PUBKEY,
@@ -81,7 +81,7 @@ fn main() -> ClientResult<()> {
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
-    update_payment(&client, mint, payment, payment_queue, recipient)?;
+    update_payment(&client, mint, payment, recipient)?;
 
     Ok(())
 }
@@ -161,26 +161,19 @@ fn update_payment(
     client: &Client,
     mint: Pubkey,
     payment: Pubkey,
-    payment_queue: Pubkey,
     recipient: Pubkey,
 ) -> ClientResult<()> {
     let update_payment_ix = Instruction {
         program_id: payments::ID,
         accounts: vec![
-            AccountMeta::new_readonly(queue_program::ID, false),
             AccountMeta::new_readonly(mint, false),
             AccountMeta::new(payment, false),
-            AccountMeta::new(payment_queue, false),
             AccountMeta::new_readonly(recipient, false),
             AccountMeta::new(client.payer_pubkey(), true),
             AccountMeta::new_readonly(system_program::ID, false),
         ],
         data: payments::instruction::UpdatePayment {
             amount: Some(50000),
-            trigger: Some(Trigger::Cron {
-                schedule: "*/4 * * * * * *".into(),
-                skippable: true,
-            }),
         }
         .data(),
     };

--- a/payments/programs/payments/src/instructions/disburse_payment.rs
+++ b/payments/programs/payments/src/instructions/disburse_payment.rs
@@ -37,7 +37,7 @@ pub struct DisbursePayment<'info> {
     #[account(
         signer, 
         address = payment_queue.pubkey(),
-        constraint = payment_queue.id.eq("payment"),
+        constraint = payment_queue.authority.eq(&payment.sender),
     )]
     pub payment_queue: Box<Account<'info, Queue>>,
 

--- a/payments/programs/payments/src/instructions/update_payment.rs
+++ b/payments/programs/payments/src/instructions/update_payment.rs
@@ -2,19 +2,11 @@ use {
     crate::state::*,
     anchor_lang::{prelude::*, solana_program::system_program},
     anchor_spl::token::Mint,
-    clockwork_sdk::queue_program::{
-        self,
-        accounts::{Queue, QueueAccount, QueueSettings, Trigger},
-        QueueProgram,
-    },
 };
 
 #[derive(Accounts)]
-#[instruction(amount: Option<u64>, trigger: Option<Trigger>)]
+#[instruction(amount: Option<u64>)]
 pub struct UpdatePayment<'info> {
-    #[account(address = queue_program::ID)]
-    pub clockwork_program: Program<'info, QueueProgram>,
-
     #[account()]
     pub mint: Account<'info, Mint>,
 
@@ -33,13 +25,6 @@ pub struct UpdatePayment<'info> {
     )]
     pub payment: Account<'info, Payment>,
 
-    #[account(
-        mut,
-        address = payment_queue.pubkey(),
-        constraint = payment_queue.authority.eq(&payment.sender),
-	  )]
-    pub payment_queue: Account<'info, Queue>,
-
     /// CHECK: this account is validated against the payment account
     #[account()]
     pub recipient: AccountInfo<'info>,
@@ -54,48 +39,13 @@ pub struct UpdatePayment<'info> {
 pub fn handler<'info>(
     ctx: Context<'_, '_, '_, 'info, UpdatePayment<'info>>,
     amount: Option<u64>,
-    trigger: Option<Trigger>,
 ) -> Result<()> {
-    // Get accounts
-    let clockwork_program = &ctx.accounts.clockwork_program;
+    // Get payment account
     let payment = &mut ctx.accounts.payment;
-    let payment_queue = &mut ctx.accounts.payment_queue;
-    let sender = &ctx.accounts.sender;
-    let system_program = &ctx.accounts.system_program;
-
-    // get payment bump
-    let bump = *ctx.bumps.get("payment").unwrap();
 
     // update amount
     if let Some(amount) = amount {
         payment.amount = amount;
-    }
-
-    // update queue trigger
-    if let Some(trigger) = trigger {
-        clockwork_sdk::queue_program::cpi::queue_update(
-            CpiContext::new_with_signer(
-                clockwork_program.to_account_info(),
-                clockwork_sdk::queue_program::cpi::accounts::QueueUpdate {
-                    authority: sender.to_account_info(),
-                    queue: payment_queue.to_account_info(),
-                    system_program: system_program.to_account_info(),
-                },
-                &[&[
-                    SEED_PAYMENT,
-                    payment.sender.as_ref(),
-                    payment.recipient.as_ref(),
-                    payment.mint.as_ref(),
-                    &[bump],
-                ]],
-            ),
-            QueueSettings {
-                fee: None,
-                kickoff_instruction: None,
-                rate_limit: None,
-                trigger: Some(trigger),
-            },
-        )?;
     }
 
     Ok(())

--- a/payments/programs/payments/src/instructions/update_payment.rs
+++ b/payments/programs/payments/src/instructions/update_payment.rs
@@ -36,7 +36,7 @@ pub struct UpdatePayment<'info> {
     #[account(
         mut,
         address = payment_queue.pubkey(),
-        constraint = payment_queue.id.eq("payment"),
+        constraint = payment_queue.authority.eq(&payment.sender),
 	  )]
     pub payment_queue: Account<'info, Queue>,
 

--- a/payments/programs/payments/src/lib.rs
+++ b/payments/programs/payments/src/lib.rs
@@ -32,13 +32,12 @@ pub mod payments {
     }
 
     /*
-     * update disbursement amount and/or schedule
+     * update disbursement amount
      */
     pub fn update_payment<'info>(
         ctx: Context<'_, '_, '_, 'info, UpdatePayment<'info>>,
         amount: Option<u64>,
-        trigger: Option<clockwork_sdk::queue_program::accounts::Trigger>,
     ) -> Result<()> {
-        update_payment::handler(ctx, amount, trigger)
+        update_payment::handler(ctx, amount)
     }
 }


### PR DESCRIPTION
- remove queue update from `payment_update` ix
- use the queue's authority vs hardcoded ID to validate queue