### PR TITLE
rename CrankResponse to ExecResponse for the rest of the examples

### DIFF
--- a/distributor/programs/distributor/src/instructions/distribute.rs
+++ b/distributor/programs/distributor/src/instructions/distribute.rs
@@ -10,7 +10,7 @@ use {
     },
     clockwork_sdk::{
         thread_program::accounts::{Thread, ThreadAccount},
-        CrankResponse,
+        ExecResponse,
     },
 };
 
@@ -61,7 +61,7 @@ pub struct Distribute<'info> {
     pub token_program: Program<'info, anchor_spl::token::Token>,
 }
 
-pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Distribute<'info>>) -> Result<CrankResponse> {
+pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Distribute<'info>>) -> Result<ExecResponse> {
     // get accounts
     let distributor = &ctx.accounts.distributor;
     let mint = &ctx.accounts.mint;
@@ -90,7 +90,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Distribute<'info>>) -> Res
         distributor.mint_amount,
     )?;
 
-    Ok(CrankResponse {
+    Ok(ExecResponse {
         next_instruction: None,
         kickoff_instruction: None,
     })

--- a/distributor/programs/distributor/src/lib.rs
+++ b/distributor/programs/distributor/src/lib.rs
@@ -27,7 +27,7 @@ pub mod distributor {
      */
     pub fn distribute<'info>(
         ctx: Context<'_, '_, '_, 'info, Distribute<'info>>,
-    ) -> Result<clockwork_sdk::CrankResponse> {
+    ) -> Result<clockwork_sdk::ExecResponse> {
         distribute::handler(ctx)
     }
 

--- a/investments/programs/investments/src/instructions/swap.rs
+++ b/investments/programs/investments/src/instructions/swap.rs
@@ -15,7 +15,7 @@ use {
         },
         token::{Token, TokenAccount},
     },
-    clockwork_sdk::{thread_program::accounts::{Thread, ThreadAccount}, CrankResponse},
+    clockwork_sdk::{thread_program::accounts::{Thread, ThreadAccount}, ExecResponse},
     std::num::NonZeroU64,
 };
 
@@ -64,7 +64,7 @@ pub struct Swap<'info> {
     pub token_program: Program<'info, Token>,
 }
 
-pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Swap<'info>>) -> Result<CrankResponse> {
+pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Swap<'info>>) -> Result<ExecResponse> {
     // get accounts
     let dex_program = &ctx.accounts.dex_program;
     let investment = &ctx.accounts.investment;
@@ -122,7 +122,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, Swap<'info>>) -> Result<Cr
     )?;
 
     // return None
-    Ok(CrankResponse { 
+    Ok(ExecResponse { 
         kickoff_instruction: None,
         next_instruction: None
     }) 

--- a/investments/programs/investments/src/lib.rs
+++ b/investments/programs/investments/src/lib.rs
@@ -63,7 +63,7 @@ pub mod investments_program {
      */
     pub fn swap<'info>(
         ctx: Context<'_, '_, '_, 'info, Swap<'info>>,
-    ) -> Result<clockwork_sdk::CrankResponse> {
+    ) -> Result<clockwork_sdk::ExecResponse> {
         swap::handler(ctx)
     }
 }

--- a/serum_crank/programs/serum_crank/src/instructions/consume_events.rs
+++ b/serum_crank/programs/serum_crank/src/instructions/consume_events.rs
@@ -6,7 +6,7 @@ use {
     },
     anchor_lang::solana_program::program::invoke_signed,
     anchor_spl::{token::TokenAccount, dex::serum_dex},
-    clockwork_sdk::{thread_program::accounts::{Thread, ThreadAccount}, CrankResponse},
+    clockwork_sdk::{thread_program::accounts::{Thread, ThreadAccount}, ExecResponse},
 };
 
 #[derive(Accounts)]
@@ -48,7 +48,7 @@ pub struct ConsumeEvents<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ConsumeEvents<'info>>) -> Result<CrankResponse> {
+pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ConsumeEvents<'info>>) -> Result<ExecResponse> {
     // Get accounts
     let crank = &ctx.accounts.crank;
     let crank_thread = &ctx.accounts.crank_thread;
@@ -93,7 +93,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ConsumeEvents<'info>>) -> 
     }
 
     // return read events ix
-    Ok(CrankResponse { 
+    Ok(ExecResponse { 
         kickoff_instruction: None,
         next_instruction: Some(
             Instruction {

--- a/serum_crank/programs/serum_crank/src/instructions/read_events.rs
+++ b/serum_crank/programs/serum_crank/src/instructions/read_events.rs
@@ -6,7 +6,7 @@ use {
         solana_program::{system_program,instruction::Instruction},
     },
     anchor_spl::{dex::serum_dex::state::{strip_header, EventQueueHeader, Event, Queue as SerumDexQueue}, token::TokenAccount},
-    clockwork_sdk::{thread_program::accounts::{Thread, ThreadAccount}, CrankResponse}
+    clockwork_sdk::{thread_program::accounts::{Thread, ThreadAccount}, ExecResponse}
 };
 
 #[derive(Accounts)]
@@ -50,7 +50,7 @@ pub struct ReadEvents<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ReadEvents<'info>>) -> Result<CrankResponse> {
+pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ReadEvents<'info>>) -> Result<ExecResponse> {
     // Get accounts
     let crank = &mut ctx.accounts.crank;
     let crank_thread = &mut ctx.accounts.crank_thread;
@@ -111,7 +111,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ReadEvents<'info>>) -> Res
     }  
     
     // return consume events ix
-    Ok(CrankResponse { 
+    Ok(ExecResponse { 
         kickoff_instruction: None,
         next_instruction: Some(
             Instruction {

--- a/serum_crank/programs/serum_crank/src/lib.rs
+++ b/serum_crank/programs/serum_crank/src/lib.rs
@@ -24,7 +24,7 @@ pub mod serum_crank {
      */
     pub fn read_events<'info>(
         ctx: Context<'_, '_, '_, 'info, ReadEvents<'info>>,
-    ) -> Result<clockwork_sdk::CrankResponse> {
+    ) -> Result<clockwork_sdk::ExecResponse> {
         read_events::handler(ctx)
     }
 
@@ -33,7 +33,7 @@ pub mod serum_crank {
      */
     pub fn consume_events<'info>(
         ctx: Context<'_, '_, '_, 'info, ConsumeEvents<'info>>,
-    ) -> Result<clockwork_sdk::CrankResponse> {
+    ) -> Result<clockwork_sdk::ExecResponse> {
         consume_events::handler(ctx)
     }
 }


### PR DESCRIPTION
- rename `CrankResponse` return type to `ExecResponse` following `Queue` to `Thread` rename