### PR TITLE
Convert `last_subscribe_timestamp` to `last_transfer_at`

### DIFF
--- a/subscriptions/client/src/commands/deactivate_subscription.rs
+++ b/subscriptions/client/src/commands/deactivate_subscription.rs
@@ -1,0 +1,31 @@
+use {
+    crate::*,
+    anchor_lang::{prelude::Pubkey, InstructionData},
+    clockwork_sdk::client::{Client, ClientResult},
+    solana_sdk::instruction::{AccountMeta, Instruction},
+};
+
+pub fn deactivate_subscription(
+    client: &Client,
+    subscription: Pubkey,
+    mint: Pubkey,
+) -> ClientResult<()> {
+    let deactivate_subscription_ix = Instruction {
+        program_id: subscriptions_program::ID,
+        accounts: vec![
+            AccountMeta::new(client.payer_pubkey(), true),
+            AccountMeta::new(subscription, false),
+            AccountMeta::new_readonly(mint, false),
+        ],
+        data: subscriptions_program::instruction::DeactivateSubscription {}.data(),
+    };
+
+    send_and_confirm_tx(
+        client,
+        [deactivate_subscription_ix].to_vec(),
+        None,
+        "deactivate_subscription".to_string(),
+    )?;
+
+    Ok(())
+}

--- a/subscriptions/client/src/commands/mod.rs
+++ b/subscriptions/client/src/commands/mod.rs
@@ -1,11 +1,15 @@
 pub mod create_mint;
 pub mod create_subscriber;
 pub mod create_subscription;
+pub mod deactivate_subscription;
 pub mod subscribe;
 pub mod unsubscribe;
+pub mod withdraw;
 
 pub use create_mint::*;
 pub use create_subscriber::*;
 pub use create_subscription::*;
+pub use deactivate_subscription::*;
 pub use subscribe::*;
 pub use unsubscribe::*;
+pub use withdraw::*;

--- a/subscriptions/client/src/commands/withdraw.rs
+++ b/subscriptions/client/src/commands/withdraw.rs
@@ -3,40 +3,30 @@ use {
     anchor_lang::{prelude::Pubkey, InstructionData},
     anchor_spl::token,
     clockwork_sdk::client::{Client, ClientResult},
-    clockwork_sdk::thread_program,
     solana_sdk::instruction::{AccountMeta, Instruction},
 };
 
-pub fn subscribe(
+pub fn withdraw(
     client: &Client,
-    subscriber: Pubkey,
-    subscription: Pubkey,
-    subscriber_token_account: Pubkey,
+    payer_token_account: Pubkey,
     subscription_bank: Pubkey,
+    subscription: Pubkey,
     mint: Pubkey,
-    subscription_thread: Pubkey,
 ) -> ClientResult<()> {
-    let subscribe_ix = Instruction {
+    let withdraw_ix = Instruction {
         program_id: subscriptions_program::ID,
         accounts: vec![
             AccountMeta::new(client.payer_pubkey(), true),
-            AccountMeta::new(subscriber, false),
-            AccountMeta::new(subscriber_token_account, false),
+            AccountMeta::new(payer_token_account, false),
             AccountMeta::new(subscription, false),
             AccountMeta::new(subscription_bank, false),
-            AccountMeta::new(subscription_thread, false),
             AccountMeta::new_readonly(mint, false),
             AccountMeta::new_readonly(token::ID, false),
-            AccountMeta::new_readonly(thread_program::ID, false),
         ],
-        data: subscriptions_program::instruction::Subscribe {}.data(),
+        data: subscriptions_program::instruction::Withdraw {}.data(),
     };
 
-    send_and_confirm_tx(
-        client,
-        [subscribe_ix].to_vec(),
-        None,
-        "subscribe".to_string(),
-    )?;
+    send_and_confirm_tx(client, [withdraw_ix].to_vec(), None, "withdraw".to_string())?;
+
     Ok(())
 }

--- a/subscriptions/client/src/main.rs
+++ b/subscriptions/client/src/main.rs
@@ -99,10 +99,24 @@ fn main() -> ClientResult<()> {
         "unsubscribe" => {
             unsubscribe(&client, subscriber.unwrap(), subscription.unwrap())?;
         }
+        "deactivate_subscription" => {
+            deactivate_subscription(&client, subscription.unwrap(), mint.unwrap())?;
+        }
+        "withdraw" => {
+            withdraw(
+                &client,
+                subscriber_token_account.unwrap(),
+                subscription_bank.unwrap(),
+                subscription.unwrap(),
+                mint.unwrap(),
+            )?;
+        }
         _ => {
             println!("Available Commands");
             println!("cargo run -- --command create_mint");
             println!("cargo run -- --command create_subscription --recurrent_amount <amount>");
+            println!("cargo run -- --command deactivate_subscription");
+            println!("cargo run -- --command withdraw");
             println!("cargo run -- --command create_subscriber");
             println!("cargo run -- --command subscribe");
             println!("cargo run -- --command unsubscribe");

--- a/subscriptions/programs/subscriptions/src/contexts/create_subscriber.rs
+++ b/subscriptions/programs/subscriptions/src/contexts/create_subscriber.rs
@@ -67,7 +67,7 @@ impl<'info> CreateSubscriber<'_> {
             ..
         } = self;
 
-        subscriber.new(payer.key(), subscription.key(), false, -1, subscriber_bump)?;
+        subscriber.new(payer.key(), subscription.key(), false, subscriber_bump)?;
 
         let disburse_payment_ix = Instruction {
             program_id: crate::ID,

--- a/subscriptions/programs/subscriptions/src/contexts/deactivate_subscription.rs
+++ b/subscriptions/programs/subscriptions/src/contexts/deactivate_subscription.rs
@@ -1,12 +1,8 @@
-use {
-    crate::{error::ErrorCode, state::*},
-    anchor_lang::prelude::*,
-    anchor_spl::token::Mint,
-};
+use {crate::state::*, anchor_lang::prelude::*, anchor_spl::token::Mint};
 
 #[derive(Accounts)]
 pub struct DeactivateSubscription<'info> {
-    #[account(mut)]
+    #[account(mut, address=subscription.owner)]
     pub payer: Signer<'info>,
     #[account(mut, address = Subscription::pda(subscription.owner.key(),subscription.subscription_id.clone()).0)]
     pub subscription: Account<'info, Subscription>,
@@ -16,13 +12,8 @@ pub struct DeactivateSubscription<'info> {
 
 impl<'info> DeactivateSubscription<'_> {
     pub fn process(&mut self) -> Result<()> {
-        let Self {
-            payer,
-            subscription,
-            ..
-        } = self;
+        let Self { subscription, .. } = self;
 
-        require!(subscription.owner == payer.key(), ErrorCode::NotOwner);
         subscription.is_active = false;
         Ok(())
     }

--- a/subscriptions/programs/subscriptions/src/contexts/deactivate_subscription.rs
+++ b/subscriptions/programs/subscriptions/src/contexts/deactivate_subscription.rs
@@ -1,0 +1,29 @@
+use {
+    crate::{error::ErrorCode, state::*},
+    anchor_lang::prelude::*,
+    anchor_spl::token::Mint,
+};
+
+#[derive(Accounts)]
+pub struct DeactivateSubscription<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(mut, address = Subscription::pda(subscription.owner.key(),subscription.subscription_id.clone()).0)]
+    pub subscription: Account<'info, Subscription>,
+    #[account(address=subscription.mint)]
+    pub mint: Account<'info, Mint>,
+}
+
+impl<'info> DeactivateSubscription<'_> {
+    pub fn process(&mut self) -> Result<()> {
+        let Self {
+            payer,
+            subscription,
+            ..
+        } = self;
+
+        require!(subscription.owner == payer.key(), ErrorCode::NotOwner);
+        subscription.is_active = false;
+        Ok(())
+    }
+}

--- a/subscriptions/programs/subscriptions/src/contexts/deactivate_subscription.rs
+++ b/subscriptions/programs/subscriptions/src/contexts/deactivate_subscription.rs
@@ -3,8 +3,8 @@ use {crate::state::*, anchor_lang::prelude::*, anchor_spl::token::Mint};
 #[derive(Accounts)]
 pub struct DeactivateSubscription<'info> {
     #[account(mut, address=subscription.owner)]
-    pub payer: Signer<'info>,
-    #[account(mut, address = Subscription::pda(subscription.owner.key(),subscription.subscription_id.clone()).0)]
+    pub owner: Signer<'info>,
+    #[account(mut, address = Subscription::pda(subscription.owner.key(),subscription.subscription_id.clone()).0, has_one=owner)]
     pub subscription: Account<'info, Subscription>,
     #[account(address=subscription.mint)]
     pub mint: Account<'info, Mint>,

--- a/subscriptions/programs/subscriptions/src/contexts/disburse_payment.rs
+++ b/subscriptions/programs/subscriptions/src/contexts/disburse_payment.rs
@@ -81,7 +81,7 @@ impl<'info> DisbursePayment<'_> {
             match amount_left {
                 Some(_) => {
                     subscriber.is_active = true;
-                    subscriber.last_subscribe_timestamp = Clock::get().unwrap().unix_timestamp;
+                    subscriber.last_transfer_at = Some(Clock::get().unwrap().unix_timestamp);
                     token::transfer(
                         CpiContext::new_with_signer(
                             token_program.to_account_info(),
@@ -118,9 +118,6 @@ impl<'info> DisbursePayment<'_> {
                 }
             }
         }
-
-        msg!("{:?}", subscriber.last_subscribe_timestamp);
-
         Ok(ExecResponse::default())
     }
 }

--- a/subscriptions/programs/subscriptions/src/contexts/mod.rs
+++ b/subscriptions/programs/subscriptions/src/contexts/mod.rs
@@ -1,11 +1,15 @@
 pub mod create_subscriber;
 pub mod create_subscription;
+pub mod deactivate_subscription;
 pub mod disburse_payment;
 pub mod subscribe;
 pub mod unsubscribe;
+pub mod withdraw;
 
 pub use create_subscriber::*;
 pub use create_subscription::*;
+pub use deactivate_subscription::*;
 pub use disburse_payment::*;
 pub use subscribe::*;
 pub use unsubscribe::*;
+pub use withdraw::*;

--- a/subscriptions/programs/subscriptions/src/contexts/subscribe.rs
+++ b/subscriptions/programs/subscriptions/src/contexts/subscribe.rs
@@ -57,7 +57,7 @@ impl<'info> Subscribe<'_> {
 
         require!(
             subscriber_token_account.amount >= subscription.recurrent_amount,
-            ErrorCode::InsuffiscientAmountLocked
+            ErrorCode::InsuffiscientAmount
         );
         require!(subscription.is_active, ErrorCode::SubscriptionInactive);
 
@@ -88,7 +88,7 @@ impl<'info> Subscribe<'_> {
         ))?;
 
         subscriber.is_active = true;
-        subscriber.last_subscribe_timestamp = Clock::get().unwrap().unix_timestamp;
+        subscriber.last_transfer_at = Some(Clock::get().unwrap().unix_timestamp);
         Ok(())
     }
 }

--- a/subscriptions/programs/subscriptions/src/contexts/withdraw.rs
+++ b/subscriptions/programs/subscriptions/src/contexts/withdraw.rs
@@ -1,0 +1,66 @@
+use {
+    crate::{error::ErrorCode, state::*},
+    anchor_lang::prelude::*,
+    anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer},
+};
+
+#[derive(Accounts)]
+pub struct Withdraw<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        token::mint = mint,
+        token::authority = payer,
+    )]
+    pub payer_token_account: Account<'info, TokenAccount>,
+
+    #[account(mut, address = Subscription::pda(subscription.owner.key(),subscription.subscription_id.clone()).0)]
+    pub subscription: Account<'info, Subscription>,
+    #[account(
+        mut,
+        token::mint = mint,
+        token::authority = subscription,
+        address = Subscription::bank_pda(subscription.key(),subscription.owner.key()).0
+    )]
+    pub subscription_bank: Account<'info, TokenAccount>,
+
+    #[account(address=subscription.mint)]
+    pub mint: Account<'info, Mint>,
+    pub token_program: Program<'info, Token>,
+}
+
+impl<'info> Withdraw<'_> {
+    pub fn process(&mut self) -> Result<()> {
+        let Self {
+            payer,
+            subscription,
+            token_program,
+            payer_token_account,
+            subscription_bank,
+            ..
+        } = self;
+
+        require!(subscription.owner == payer.key(), ErrorCode::NotOwner);
+
+        token::transfer(
+            CpiContext::new_with_signer(
+                token_program.to_account_info(),
+                Transfer {
+                    authority: subscription.to_account_info(),
+                    from: subscription_bank.to_account_info(),
+                    to: payer_token_account.to_account_info(),
+                },
+                &[&[
+                    SEED_SUBSCRIPTION,
+                    payer.key().as_ref(),
+                    &subscription.subscription_id.to_be_bytes(),
+                    &[subscription.bump],
+                ]],
+            ),
+            subscription_bank.amount,
+        )?;
+
+        Ok(())
+    }
+}

--- a/subscriptions/programs/subscriptions/src/error.rs
+++ b/subscriptions/programs/subscriptions/src/error.rs
@@ -6,4 +6,6 @@ pub enum ErrorCode {
     InsuffiscientAmount,
     #[msg("Subscription is inactive")]
     SubscriptionInactive,
+    #[msg("payer is not the owner of the subscription")]
+    NotOwner,
 }

--- a/subscriptions/programs/subscriptions/src/error.rs
+++ b/subscriptions/programs/subscriptions/src/error.rs
@@ -2,8 +2,8 @@ use anchor_lang::prelude::*;
 
 #[error_code]
 pub enum ErrorCode {
-    #[msg("Insuffiscient amount locked to withdraw")]
-    InsuffiscientAmountLocked,
+    #[msg("Insuffiscient amount to transfer")]
+    InsuffiscientAmount,
     #[msg("Subscription is inactive")]
     SubscriptionInactive,
 }

--- a/subscriptions/programs/subscriptions/src/lib.rs
+++ b/subscriptions/programs/subscriptions/src/lib.rs
@@ -34,6 +34,20 @@ pub mod subscriptions_program {
     }
 
     /*
+     * Deactivate subscription
+     */
+    pub fn deactivate_subscription<'info>(ctx: Context<DeactivateSubscription>) -> Result<()> {
+        ctx.accounts.process()
+    }
+
+    /*
+     * Withdraw from subscription bank
+     */
+    pub fn withdraw<'info>(ctx: Context<Withdraw>) -> Result<()> {
+        ctx.accounts.process()
+    }
+
+    /*
      * create subscriber
      */
     pub fn create_subscriber<'info>(

--- a/subscriptions/programs/subscriptions/src/state/subscriber.rs
+++ b/subscriptions/programs/subscriptions/src/state/subscriber.rs
@@ -15,7 +15,7 @@ pub struct Subscriber {
     pub owner: Pubkey,
     pub subscription: Pubkey,
     pub is_active: bool,
-    pub last_subscribe_timestamp: i64,
+    pub last_transfer_at: Option<i64>,
     pub bump: u8,
 }
 
@@ -36,14 +36,8 @@ impl TryFrom<Vec<u8>> for Subscriber {
 }
 
 pub trait SubscriberAccount {
-    fn new(
-        &mut self,
-        owner: Pubkey,
-        subscription: Pubkey,
-        is_active: bool,
-        last_subscribe_timestamp: i64,
-        bump: u8,
-    ) -> Result<()>;
+    fn new(&mut self, owner: Pubkey, subscription: Pubkey, is_active: bool, bump: u8)
+        -> Result<()>;
 }
 
 impl SubscriberAccount for Account<'_, Subscriber> {
@@ -52,13 +46,12 @@ impl SubscriberAccount for Account<'_, Subscriber> {
         owner: Pubkey,
         subscription: Pubkey,
         is_active: bool,
-        last_subscribe_timestamp: i64,
         bump: u8,
     ) -> Result<()> {
         self.owner = owner;
         self.subscription = subscription;
         self.is_active = is_active;
-        self.last_subscribe_timestamp = last_subscribe_timestamp;
+        self.last_transfer_at = None;
         self.bump = bump;
         Ok(())
     }

--- a/subscriptions/programs/subscriptions/src/state/subscription.rs
+++ b/subscriptions/programs/subscriptions/src/state/subscription.rs
@@ -72,7 +72,7 @@ impl SubscriptionAccount for Account<'_, Subscription> {
         mint: Pubkey,
         recurrent_amount: u64,
         schedule: String,
-        is_acitve: bool,
+        is_active: bool,
         subscription_id: u64,
         bump: u8,
     ) -> Result<()> {
@@ -80,7 +80,7 @@ impl SubscriptionAccount for Account<'_, Subscription> {
         self.mint = mint;
         self.recurrent_amount = recurrent_amount;
         self.schedule = schedule;
-        self.is_active = is_acitve;
+        self.is_active = is_active;
         self.subscription_id = subscription_id;
         self.bump = bump;
         Ok(())


### PR DESCRIPTION
Keeping track of when the last subscribe call was made is not as important as keeping track of when the last disbursement happened. It would be more useful for merchants if we kept a last_transfer_at: Option<i64> with the timestamp that is updated on ever DisbursePayment instruction. 